### PR TITLE
{gentoo,vanilla}-kernel: build with signed modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+signing_key.pem
+localconfig.bash
+local.diff

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE
 FROM ${BASE}
 
 CMD cp -a /var/cache/binpkgs /tmp/binpkg \
- && FEATURES=test emerge -1vB ${PKG} \
+ && FEATURES=test MODULES_SIGN_KEY="/tmp/signing_key.pem" emerge -1vB ${PKG} \
  && emerge -1vk ${PKG} \
  && rsync -av --checksum /tmp/binpkg/. /var/cache/binpkgs/ \
  && { [[ -z ${POST_PKGS} ]] || emerge -1vt --keep-going=y --jobs ${POST_PKGS}; }

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -11,6 +11,8 @@ ARG LDFLAGS
 
 COPY package.accept_keywords /etc/portage/package.accept_keywords/local
 COPY package.use /etc/portage/package.use/local
+COPY kernel-configd /etc/kernel/config.d/local.config
+COPY signing_key.pem /tmp/signing_key.pem
 RUN printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nLDFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-T1 -9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\nBINPKG_FORMAT="gpkg"\n' "${CFLAGS}" "${CFLAGS}" "${LDFLAGS}" >> /etc/portage/make.conf \
  && { [[ -z ${DEPS} ]] || emerge -1vt --jobs ${DEPS}; } \
  && emerge --info \

--- a/build.bash
+++ b/build.bash
@@ -32,6 +32,7 @@ export_vars() {
 					virtual/libelf
 					sys-devel/bc
 					app-emulation/qemu
+					dev-libs/openssl
 					dev-tcltk/expect
 					sys-kernel/dracut
 					net-misc/openssh

--- a/kernel-configd
+++ b/kernel-configd
@@ -1,0 +1,3 @@
+## Leave this up to the user, can be enabled with
+## module.sig_enforce=1 or by enabling secureboot.
+# CONFIG_MODULE_SIG_FORCE is not set

--- a/package.use
+++ b/package.use
@@ -11,9 +11,9 @@ app-emulation/qemu -aio -caps -filecaps -jpeg -ncurses -png -vhost-net -vnc -xat
 #dev-python/cryptography PYTHON_TARGETS: pypy3
 
 # for kernel testing
-sys-kernel/gentoo-kernel test -strip
+sys-kernel/gentoo-kernel modules-sign test
 sys-kernel/gentoo-kernel-bin test
-sys-kernel/vanilla-kernel test -strip
+sys-kernel/vanilla-kernel modules-sign test
 sys-kernel/vanilla-kernel-bin test
 app-crypt/tpm-emulator modules
 dev-util/sysdig modules


### PR DESCRIPTION
Disable enforcing of signatures by default. Leave this up to the kernel command line (`module.sig_enforce=1`) or secureboot status. This ensures gentoo-kernel-bin doesn't suddenly fail to load third-party modules unless signatures are explicitly enforced by the user.

Also add a `.gitignore` to prevent committing local files (specifically the key, which we really don't want to commit by accident).

Stripping is now enabled since we have to strip **before** signing (or not strip at all).

Accompanying PR for the ::gentoo ebuild will follow in a bit.

Documentation for signing (and enforcing signatures on) third-party modules will follow after merging (this involves `sys-boot/shim` and `sys-boot/mokutil`).

This is an alternative simpler approach to https://github.com/gentoo/gentoo/pull/31988 that does not abuse `linux-mod-r1.eclass` and does not require shim/mokutil unless third-party modules are used.

CC @mgorny @ionenwks 
