### PR TITLE
Also sign the kernel image itself for use with Secure Boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ ARG BASE
 FROM ${BASE}
 
 CMD cp -a /var/cache/binpkgs /tmp/binpkg \
- && FEATURES=test MODULES_SIGN_KEY="/tmp/signing_key.pem" emerge -1vB ${PKG} \
+ && FEATURES=test \
+ MODULES_SIGN_KEY="/tmp/signing_key.pem" \
+ SECUREBOOT_SIGN_KEY="/tmp/signing_key.pem" \
+ SECUREBOOT_SIGN_CERT="/tmp/signing_key.pem" emerge -1vB ${PKG} \
  && emerge -1vk ${PKG} \
  && rsync -av --checksum /tmp/binpkg/. /var/cache/binpkgs/ \
  && { [[ -z ${POST_PKGS} ]] || emerge -1vt --keep-going=y --jobs ${POST_PKGS}; }

--- a/package.use
+++ b/package.use
@@ -11,9 +11,9 @@ app-emulation/qemu -aio -caps -filecaps -jpeg -ncurses -png -vhost-net -vnc -xat
 #dev-python/cryptography PYTHON_TARGETS: pypy3
 
 # for kernel testing
-sys-kernel/gentoo-kernel modules-sign test
+sys-kernel/gentoo-kernel modules-sign secureboot test
 sys-kernel/gentoo-kernel-bin test
-sys-kernel/vanilla-kernel modules-sign test
+sys-kernel/vanilla-kernel modules-sign secureboot test
 sys-kernel/vanilla-kernel-bin test
 app-crypt/tpm-emulator modules
 dev-util/sysdig modules


### PR DESCRIPTION
https://github.com/gentoo/gentoo/pull/32464 is a prerequisite for this PR.


This will NOT work with UKIs as they are always generated locally and therefore have to be signed locally. USE=secureboot on gentoo-kernel-bin accomplishes this but does require the user to have their own key.

Actually booting with Secure Boot enabled will require that the user adds our certificate to their UEFI key database or to their shim MOK list.

I suggest to just use the same key as for the modules to keep things simple.

CC @mgorny @thesamesam 