### PR TITLE
Export prebuilt initrd's and prebuilt signed uki's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE
 FROM ${BASE}
 
 CMD cp -a /var/cache/binpkgs /tmp/binpkg \
- && FEATURES=test emerge -1vB ${PKG} \
+ && FEATURES=test CFLAGS="${CFLAGS}" CXXFLAGS="${CFLAGS}" emerge -1vB ${PKG} \
  && emerge -1vk ${PKG} \
  && rsync -av --checksum /tmp/binpkg/. /var/cache/binpkgs/ \
  && { [[ -z ${POST_PKGS} ]] || emerge -1vt --keep-going=y --jobs ${POST_PKGS}; }

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -10,10 +10,11 @@ RUN wget --progress=dot:mega -O - https://github.com/gentoo-mirror/gentoo/archiv
 ARG DOCKER_DEPS
 ARG CFLAGS
 ARG LDFLAGS
+ARG USE
 
 COPY package.accept_keywords /etc/portage/package.accept_keywords/local
 COPY package.use /etc/portage/package.use/local
-RUN printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nLDFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-T1 -9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip parallel-install -ipc-sandbox -network-sandbox -pid-sandbox"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\nBINPKG_FORMAT="gpkg"\nPORTAGE_BINHOST="http://127.0.0.1:8787/"\nMODULES_SIGN_KEY="/tmp/signing_key.pem"\nSECUREBOOT_SIGN_KEY="/tmp/signing_key.pem"\nSECUREBOOT_SIGN_CERT="/tmp/signing_key.pem"\n' "${CFLAGS}" "${CFLAGS}" "${LDFLAGS}" >> /etc/portage/make.conf \
+RUN printf '\nCFLAGS="%s"\nCXXFLAGS="%s"\nLDFLAGS="%s"\nBINPKG_COMPRESS="xz"\nBINPKG_COMPRESS_FLAGS="-T1 -9"\nFEATURES="${FEATURES} -sandbox -usersandbox -cgroup binpkg-multi-instance -binpkg-docompress -binpkg-dostrip parallel-install -ipc-sandbox -network-sandbox -pid-sandbox"\nACCEPT_LICENSE="*"\nPKGDIR="/tmp/binpkg"\nBINPKG_FORMAT="gpkg"\nPORTAGE_BINHOST="http://127.0.0.1:8787/"\nMODULES_SIGN_KEY="/tmp/signing_key.pem"\nSECUREBOOT_SIGN_KEY="/tmp/signing_key.pem"\nSECUREBOOT_SIGN_CERT="/tmp/signing_key.pem"\nUSE="%s"\n' "${CFLAGS}" "${CFLAGS}" "${LDFLAGS}" "${USE}" >> /etc/portage/make.conf \
  && rm -rf /etc/portage/binrepos.conf \
  && { [[ -z ${DOCKER_DEPS} ]] || PKGDIR=/tmp/binpkg-cache emerge -1vbgUt --jobs ${DOCKER_DEPS}; } \
  && emerge --info \

--- a/build.bash
+++ b/build.bash
@@ -26,10 +26,132 @@ export_vars() {
 
 	case ${target} in
 		build-*-kernel-deps)
-			local sb_dep=
-			if [[ ${target_arch} != ppc64* ]]; then
-				sb_dep='app-crypt/sbsigntools'
-			fi
+			local deps='
+				app-emulation/qemu
+				dev-lang/python:3.12
+				dev-libs/openssl
+				dev-tcltk/expect
+				dev-util/cmake
+				net-misc/openssh
+				sys-devel/bc
+				sys-kernel/dracut
+				sys-kernel/installkernel-gentoo
+				virtual/libelf
+			'
+			case ${target_arch} in
+				amd64|x86)
+					deps+='
+						sys-firmware/intel-microcode
+					'
+					;&
+				amd64|arm64|x86)
+					deps+='
+						app-crypt/sbsigntools
+						app-alternatives/awk
+						app-alternatives/gzip
+						app-alternatives/sh
+						app-arch/bzip2
+						app-arch/gzip
+						app-arch/lz4
+						app-arch/xz-utils
+						app-arch/zstd
+						app-crypt/argon2
+						app-crypt/gnupg
+						app-crypt/p11-kit
+						app-crypt/tpm2-tools
+						app-crypt/tpm2-tss
+						app-misc/ddcutil
+						app-misc/jq
+						app-shells/bash
+						dev-db/sqlite
+						dev-libs/cyrus-sasl
+						dev-libs/expat
+						dev-libs/glib
+						dev-libs/hidapi
+						dev-libs/icu
+						dev-libs/json-c
+						dev-libs/libaio
+						dev-libs/libassuan
+						dev-libs/libevent
+						dev-libs/libffi
+						dev-libs/libgcrypt
+						dev-libs/libgpg-error
+						dev-libs/libp11
+						dev-libs/libpcre2
+						dev-libs/libtasn1
+						dev-libs/libunistring
+						dev-libs/libusb
+						dev-libs/lzo
+						dev-libs/npth
+						dev-libs/nss
+						dev-libs/oniguruma
+						dev-libs/opensc
+						dev-libs/userspace-rcu
+						media-libs/libmtp
+						media-libs/libv4l
+						net-dns/c-ares
+						net-dns/libidn2
+						net-fs/cifs-utils
+						net-fs/nfs-utils
+						net-fs/samba
+						net-libs/libmnl
+						net-libs/libndp
+						net-libs/libtirpc
+						net-libs/nghttp2
+						net-misc/curl
+						net-misc/dhcp
+						net-misc/networkmanager
+						net-nds/openldap
+						net-wireless/bluez
+						net-wireless/iwd
+						sys-apps/acl
+						sys-apps/attr
+						sys-apps/baselayout
+						sys-apps/coreutils
+						sys-apps/dbus
+						sys-apps/fwupd
+						sys-apps/gawk
+						sys-apps/hwdata
+						sys-apps/iproute2
+						sys-apps/kbd
+						sys-apps/keyutils
+						sys-apps/kmod
+						sys-apps/less
+						sys-apps/nvme-cli
+						sys-apps/pcsc-lite
+						sys-apps/rng-tools
+						sys-apps/sed
+						sys-apps/shadow
+						sys-apps/systemd
+						sys-apps/util-linux
+						sys-auth/polkit
+						sys-block/nbd
+						sys-devel/gcc
+						sys-fs/btrfs-progs
+						sys-fs/cryptsetup
+						sys-fs/dmraid
+						sys-fs/dosfstools
+						sys-fs/e2fsprogs
+						sys-fs/lvm2
+						sys-fs/mdadm
+						sys-fs/multipath-tools
+						sys-fs/xfsprogs
+						sys-kernel/linux-firmware
+						sys-libs/glibc
+						sys-libs/libapparmor
+						sys-libs/libcap
+						sys-libs/libcap-ng
+						sys-libs/libnvme
+						sys-libs/libseccomp
+						sys-libs/libxcrypt
+						sys-libs/ncurses
+						sys-libs/pam
+						sys-libs/readline
+						sys-libs/zlib
+						sys-process/procps
+					'
+					;;
+			esac
 
 			# we need systemd for initramfs
 			rc=systemd
@@ -38,18 +160,7 @@ export_vars() {
 				build
 				--label=mgorny-binpkg-docker
 				-f Dockerfile.deps
-				--build-arg DOCKER_DEPS="
-					virtual/libelf
-					sys-devel/bc
-					app-emulation/qemu
-					dev-libs/openssl
-					dev-tcltk/expect
-					sys-kernel/dracut
-					net-misc/openssh
-					dev-lang/python:3.12
-					dev-util/cmake
-					${sb_dep}
-				"
+				--build-arg DOCKER_DEPS="${deps}"
 				--network host
 				-t "${target}" .
 			)

--- a/build.bash
+++ b/build.bash
@@ -11,6 +11,9 @@ export_vars() {
 	local target=${1}
 	local target_arch binpkg
 	local rc=openrc
+	local cflags='-mtune=generic -O2 -pipe'
+	local ldflags='-Wl,-O1 -Wl,--as-needed'
+	local use=
 
 	: ${DOCKER:=docker}
 	: ${BINPKGROOT=~/binpkg}
@@ -155,6 +158,9 @@ export_vars() {
 
 			# we need systemd for initramfs
 			rc=systemd
+			# Optimize for smaller initrd
+			cflags=${cflags/-O2/-Oz -flto}
+			use=lto
 
 			DOCKER_ARGS+=(
 				build
@@ -291,8 +297,6 @@ export_vars() {
 			;;
 	esac
 
-	local cflags='-mtune=generic -O2 -pipe'
-	local ldflags='-Wl,-O1 -Wl,--as-needed'
 	local stage
 	case ${target_arch} in
 		amd64)
@@ -349,6 +353,7 @@ export_vars() {
 				--build-arg "BASE=${stage}"
 				--build-arg "CFLAGS=${cflags}"
 				--build-arg "LDFLAGS=${ldflags}"
+				--build-arg "USE=${use}"
 			)
 		fi
 	fi

--- a/package.accept_keywords
+++ b/package.accept_keywords
@@ -12,13 +12,22 @@ dev-python/pypy3_9-exe-bin **
 dev-python/pypy3_10 **
 dev-python/pypy3_10-exe **
 dev-python/pypy3_10-exe-bin **
+sys-firmware/intel-microcode
 sys-kernel/dracut
 sys-kernel/gentoo-kernel
 sys-kernel/gentoo-kernel-bin
+sys-kernel/linux-firmware
 sys-kernel/vanilla-kernel
 sys-kernel/vanilla-kernel-bin
 virtual/dist-kernel
 app-emulation/qemu
+
+# initramfs deps
+dev-libs/opensc
+sys-apps/fwupd
+sys-block/nbd
+dev-libs/libjcat
+sys-libs/libapparmor
 
 # for pypy3 testing
 dev-python/setuptools
@@ -30,8 +39,10 @@ virtual/python-enum34
 dev-python/cryptography
 
 # for kernel testing
+app-crypt/gnupg
 dev-util/pahole
 sys-apps/debianutils
+sys-apps/systemd
 sys-kernel/installkernel-gentoo
 dev-libs/libb64
 net-libs/grpc
@@ -51,10 +62,12 @@ net-firewall/xtables-addons
 net-fs/openafs
 net-misc/AQtion
 net-misc/ena-driver
+net-misc/networkmanager
 net-misc/openvswitch
 net-vpn/wireguard-modules
 net-wireless/broadcom-sta
 sci-libs/linux-gpib-modules
+sys-apps/dbus
 sys-cluster/knem
 sys-fs/loop-aes
 sys-fs/vhba

--- a/package.use
+++ b/package.use
@@ -11,8 +11,8 @@ app-emulation/qemu -aio -caps -filecaps -jpeg -ncurses -png -vhost-net -vnc -xat
 #dev-python/cryptography PYTHON_TARGETS: pypy3
 
 # for kernel testing
-sys-kernel/gentoo-kernel modules-sign secureboot test
-sys-kernel/gentoo-kernel-bin test
+sys-kernel/gentoo-kernel generic-uki modules-sign secureboot test
+sys-kernel/gentoo-kernel-bin test generic-uki
 sys-kernel/vanilla-kernel modules-sign secureboot test
 sys-kernel/vanilla-kernel-bin test
 app-crypt/tpm-emulator modules
@@ -27,3 +27,12 @@ sys-cluster/lustre modules
 sys-kernel/kpatch kmod
 x11-drivers/nvidia-drivers -tools -X
 sys-apps/util-linux caps
+
+# for initramfs/uki building
+app-crypt/gnupg smartcard tpm
+net-misc/networkmanager iwd
+sys-fs/lvm2 lvm
+sys-kernel/linux-firmware -initramfs deduplicate redistributable
+sys-firmware/intel-microcode -hostonly -initramfs split-ucode
+sys-kernel/installkernel-gentoo -dracut uki -ukify
+sys-apps/systemd boot cryptsetup kernel-install pkcs11 policykit tpm udev ukify


### PR DESCRIPTION
This changes the following:
- we add a default `dracut.conf`
- we add some extra dependencies required to create an useful initrd and unified kernel image, most importantly we add the cpu microcode packages required to update the microcode early in the initrd
- small fix in package.accept_keywords for a package rename
- new function `get_kernel_image_dir`, adapted from `dist-kernel-utils.eclass`, which we use to find the generatedinitrd and uki
- if we are building a kernel gpkg:
  - copy the generated initrd, then
  - switch out `uefi=no` with `uefi=yes` in our `dracut.conf`, then
  - reinstall the kernel again
  - copy the generated uki (it is signed with the same key as the main kernel image and kernel modules)

I'm far from an expert with docker, so there may be more elegant ways to do this. That being said, I can successfully boot my system with both the kernel+initrd and uki that I built in the docker container. I consider this experimental since I cannot be sure this will boot every system, that being said the pre-signed, pre-built uki is a requested feature and it is useful for those who want the added security of a verified initrd but do not want to generate and maintain their own key.

A next step would be to, by default, accept the key we use to sign everything here in `sys-boot/shim` MOK list. That is, if that is possible without building shim from source, I still have to investigate this.

Changes for the ebuild will follow in a separate PR soon. Note that no further changes are required to installkernel-gentoo or installkernel-systemd. For installkernel-gentoo we simply prevent the installation of the dracut plugin. And installkernel-systemd will find the initrd and uki.efi in the same directory as the kernel image and will use this instead of generating a new one.

CC @mgorny @thesamesam @ArsenArsen 