### PR TITLE
*: move installkernel-{gentoo,systemd} -> installkernel

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -38,7 +38,7 @@ export_vars() {
 				net-misc/openssh
 				sys-devel/bc
 				sys-kernel/dracut
-				sys-kernel/installkernel-systemd
+				sys-kernel/installkernel
 				virtual/libelf
 			'
 			case ${target_arch} in

--- a/package.accept_keywords
+++ b/package.accept_keywords
@@ -43,7 +43,7 @@ app-crypt/gnupg
 dev-util/pahole
 sys-apps/debianutils
 sys-apps/systemd
-sys-kernel/installkernel-gentoo
+sys-kernel/installkernel
 dev-libs/libb64
 net-libs/grpc
 app-crypt/pesign

--- a/package.use
+++ b/package.use
@@ -11,10 +11,10 @@ app-emulation/qemu -aio -caps -filecaps -jpeg -ncurses -png -vhost-net -vnc -xat
 #dev-python/cryptography PYTHON_TARGETS: pypy3
 
 # for kernel testing
-sys-kernel/gentoo-kernel generic-uki modules-sign secureboot test
-sys-kernel/gentoo-kernel-bin test generic-uki
-sys-kernel/vanilla-kernel modules-sign secureboot test
-sys-kernel/vanilla-kernel-bin test
+sys-kernel/gentoo-kernel generic-uki modules-sign secureboot test -initramfs
+sys-kernel/gentoo-kernel-bin test generic-uki -initramfs
+sys-kernel/vanilla-kernel modules-sign secureboot test -initramfs
+sys-kernel/vanilla-kernel-bin test -initramfs
 app-crypt/tpm-emulator modules
 dev-util/sysdig modules
 net-dialup/accel-ppp ipoe
@@ -34,5 +34,5 @@ net-misc/networkmanager iwd
 sys-fs/lvm2 lvm
 sys-kernel/linux-firmware -initramfs deduplicate redistributable
 sys-firmware/intel-microcode -hostonly -initramfs split-ucode
-sys-kernel/installkernel-gentoo -dracut uki -ukify
+sys-kernel/installkernel -dracut -grub uki -ukify
 sys-apps/systemd boot cryptsetup kernel-install pkcs11 policykit tpm udev ukify


### PR DESCRIPTION
We disable `USE=initramfs` on the kernel to avoid a dependency conflict where `kernel-install.eclass` wants +dracut on arches where we do not build generic-uki, but -dracut on arches where we do build a generic-uki.

It doesn't really matter for us that no initramfs will be generated in postinst anyway, in fact it might make the builds ever so slightly faster.