### PR TITLE
package.use: drop USE=uki from installkernel

### DIFF
--- a/package.use
+++ b/package.use
@@ -34,5 +34,5 @@ net-misc/networkmanager iwd
 sys-fs/lvm2 lvm
 sys-kernel/linux-firmware -initramfs deduplicate redistributable
 sys-firmware/intel-microcode -hostonly -initramfs split-ucode
-sys-kernel/installkernel -dracut -grub uki -ukify
+sys-kernel/installkernel -dracut -grub -ukify
 sys-apps/systemd boot cryptsetup kernel-install pkcs11 policykit tpm udev ukify


### PR DESCRIPTION
When we are not building a generic uki (i.e. on x86) and also have uki_generator=none (USE=-ukify). Then there will be no uki to install and 60-ukify.install will fall back to installing the passed kernel image which fails because it is not an efi exuctable.