### PR TITLE
plymouthd.conf: add basic plymouth config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ CMD cp -a /var/cache/binpkgs /tmp/binpkg \
 
 COPY signing_key.pem /tmp/signing_key.pem
 COPY kernel-configd /etc/kernel/config.d/local.config
+COPY plymouthd.conf /etc/plymouth/plymouthd.conf
 COPY local.diff /
 RUN patch -p1 -d /var/db/repos/gentoo < /local.diff \
  && rm /local.diff

--- a/build.bash
+++ b/build.bash
@@ -132,6 +132,7 @@ export_vars() {
 						sys-apps/systemd
 						sys-apps/util-linux
 						sys-auth/polkit
+						sys-boot/plymouth
 						sys-block/nbd
 						sys-devel/gcc
 						sys-fs/btrfs-progs
@@ -156,6 +157,7 @@ export_vars() {
 						sys-libs/readline
 						sys-libs/zlib
 						sys-process/procps
+						x11-libs/libdrm
 					'
 					;;
 				x86)

--- a/package.use
+++ b/package.use
@@ -36,3 +36,8 @@ sys-kernel/linux-firmware -initramfs deduplicate redistributable
 sys-firmware/intel-microcode -hostonly -initramfs split-ucode
 sys-kernel/installkernel -dracut -grub -ukify
 sys-apps/systemd boot cryptsetup kernel-install pkcs11 policykit tpm udev ukify
+sys-boot/plymouth drm pango systemd udev
+x11-libs/pango X
+x11-libs/cairo X
+media-libs/libglvnd X
+

--- a/plymouthd.conf
+++ b/plymouthd.conf
@@ -1,0 +1,2 @@
+[Daemon]
+Theme=bgrt


### PR DESCRIPTION
This is just to ensure that the dracut plymouth module uses the lightweight bgrt theme in the generic-uki. I have been looking for a way to do this from the eclass, but this appears to be impossible, the dracut plymouth module calls `/usr/libexec/plymouth/plymouth-populate-initrd` and always uses the config file in `/etc/plymouth`.